### PR TITLE
Basic types - Bool and Nat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,15 @@ For simplicity, this programming language only supports type checking and evalua
 - [x] Unit tests
 - [x] Let Binding (not verified)
 - [ ] Extended basic types
-
-      - [x] Bool
-      - [x] Nat
-      - [ ] Product
-      - [ ] Sum
-      - [ ] List
-
+  - [x] Bool
+  - [x] Nat
+  - [ ] Product
+  - [ ] Sum
+  - [ ] List
 - [ ] If-Else clause
 - [ ] Parser
 - [ ] Top-level definitions
-
-Maybe in future
-
 - [ ] Fixpoint for recursive functions
-- [ ] GADT
-- [ ] Existential types
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ For simplicity, this programming language only supports type checking and evalua
 - [x] Examples
 - [x] Unit tests
 - [x] Let Binding (not verified)
-- [ ] Extended basic types (Nat, Boolean, List, ...)
+- [ ] Extended basic types
+
+      - [x] Bool
+      - [x] Nat
+      - [ ] Product
+      - [ ] Sum
+      - [ ] List
+
 - [ ] If-Else clause
 - [ ] Parser
 - [ ] Top-level definitions

--- a/src/Dynamic/Step.hs
+++ b/src/Dynamic/Step.hs
@@ -4,6 +4,8 @@ import Syntax.Expr
 
 value :: Expr -> Bool
 value EUnit = True
+value ETrue = True
+value EFalse = True
 value (ELam _ _) = True
 value _ = False
 
@@ -12,6 +14,8 @@ substitute :: EVar -> Expr -> Expr -> Expr
 substitute x e1 e2 = case e2 of
   EVar y -> if x == y then e1 else EVar y
   EUnit -> EUnit
+  ETrue -> ETrue
+  EFalse -> EFalse
   abs@(ELam y e2') -> if x == y then abs else ELam y $ substitute x e1 e2'
   EApp e21 e22 -> EApp (substitute x e1 e21) (substitute x e1 e22)
   EAnno e2' _ -> substitute x e1 e2'
@@ -24,6 +28,8 @@ eval e = let e' = step e in if e' == e then e else eval e'
 step :: Expr -> Expr
 step expr = case expr of
   EUnit -> EUnit
+  ETrue -> ETrue
+  EFalse -> EFalse
   abs@(ELam _ _) -> abs
   EApp e1 e2 | not $ value e1 -> EApp (step e1) e2
   EApp e1 e2 | not $ value e2 -> EApp e1 (step e2)

--- a/src/Dynamic/Step.hs
+++ b/src/Dynamic/Step.hs
@@ -6,6 +6,8 @@ value :: Expr -> Bool
 value EUnit = True
 value ETrue = True
 value EFalse = True
+value EZero = True
+value (ESucc n) = value n
 value (ELam _ _) = True
 value _ = False
 
@@ -16,6 +18,8 @@ substitute x e1 e2 = case e2 of
   EUnit -> EUnit
   ETrue -> ETrue
   EFalse -> EFalse
+  EZero -> EZero
+  ESucc n -> ESucc $ substitute x e1 n
   abs@(ELam y e2') -> if x == y then abs else ELam y $ substitute x e1 e2'
   EApp e21 e22 -> EApp (substitute x e1 e21) (substitute x e1 e22)
   EAnno e2' _ -> substitute x e1 e2'
@@ -30,6 +34,8 @@ step expr = case expr of
   EUnit -> EUnit
   ETrue -> ETrue
   EFalse -> EFalse
+  EZero -> EZero
+  ESucc n -> ESucc $ step n
   abs@(ELam _ _) -> abs
   EApp e1 e2 | not $ value e1 -> EApp (step e1) e2
   EApp e1 e2 | not $ value e2 -> EApp e1 (step e2)

--- a/src/Static/WellForm.hs
+++ b/src/Static/WellForm.hs
@@ -8,6 +8,7 @@ typeWellForm :: Context -> Type -> Bool
 typeWellForm ctx (TVar alpha) = CVar alpha `ctxElem` ctx
 typeWellForm ctx TUnit = True
 typeWellForm ctx TBool = True
+typeWellForm ctx TNat = True
 typeWellForm ctx (TArr a b) = typeWellForm ctx a && typeWellForm ctx b
 typeWellForm ctx (TAll alpha a) = typeWellForm (ctx |> CVar alpha) a
 typeWellForm ctx (TEVar ea) =

--- a/src/Static/WellForm.hs
+++ b/src/Static/WellForm.hs
@@ -7,6 +7,7 @@ import Syntax.Type
 typeWellForm :: Context -> Type -> Bool
 typeWellForm ctx (TVar alpha) = CVar alpha `ctxElem` ctx
 typeWellForm ctx TUnit = True
+typeWellForm ctx TBool = True
 typeWellForm ctx (TArr a b) = typeWellForm ctx a && typeWellForm ctx b
 typeWellForm ctx (TAll alpha a) = typeWellForm (ctx |> CVar alpha) a
 typeWellForm ctx (TEVar ea) =

--- a/src/Syntax/Context.hs
+++ b/src/Syntax/Context.hs
@@ -71,6 +71,7 @@ applyCtx gamma ty = case ty of
   TVar _ -> ty
   TUnit -> TUnit
   TBool -> TBool
+  TNat -> TNat
   TEVar alpha -> maybe ty (applyCtx gamma) $ ctxSolve gamma alpha
   TArr a b -> TArr (applyCtx gamma a) (applyCtx gamma b)
   TAll alpha a -> TAll alpha $ applyCtx gamma a

--- a/src/Syntax/Context.hs
+++ b/src/Syntax/Context.hs
@@ -70,6 +70,7 @@ applyCtx :: Context -> Type -> Type
 applyCtx gamma ty = case ty of
   TVar _ -> ty
   TUnit -> TUnit
+  TBool -> TBool
   TEVar alpha -> maybe ty (applyCtx gamma) $ ctxSolve gamma alpha
   TArr a b -> TArr (applyCtx gamma a) (applyCtx gamma b)
   TAll alpha a -> TAll alpha $ applyCtx gamma a

--- a/src/Syntax/Expr.hs
+++ b/src/Syntax/Expr.hs
@@ -23,6 +23,8 @@ data Expr
   | EUnit
   | ETrue
   | EFalse
+  | EZero
+  | ESucc Expr
   | ELam EVar Expr
   | EApp Expr Expr
   | EAnno Expr Type

--- a/src/Syntax/Expr.hs
+++ b/src/Syntax/Expr.hs
@@ -21,6 +21,8 @@ evar = MkEVar
 data Expr
   = EVar EVar
   | EUnit
+  | ETrue
+  | EFalse
   | ELam EVar Expr
   | EApp Expr Expr
   | EAnno Expr Type

--- a/src/Syntax/Type.hs
+++ b/src/Syntax/Type.hs
@@ -28,6 +28,7 @@ newtype TEVar = MkTEVar String deriving (Eq, Show, Ord, IsString)
 
 data Type
   = TUnit
+  | TBool
   | TVar TVar
   | TEVar TEVar
   | TArr Type Type
@@ -42,6 +43,7 @@ infixr 2 -->
 -- | Monotypes: tau, sigma.
 isMono :: Type -> Bool
 isMono TUnit = True
+isMono TBool = True
 isMono (TVar _) = True
 isMono (TEVar _) = True
 isMono (TArr a b) = isMono a && isMono b
@@ -49,6 +51,7 @@ isMono _ = False
 
 tyFreeTEVars :: Type -> Set TEVar
 tyFreeTEVars TUnit = S.empty
+tyFreeTEVars TBool = S.empty
 tyFreeTEVars (TVar _) = S.empty
 tyFreeTEVars (TEVar evar) = S.singleton evar
 tyFreeTEVars (TArr a b) = tyFreeTEVars a <> tyFreeTEVars b
@@ -56,6 +59,7 @@ tyFreeTEVars (TAll _ ty) = tyFreeTEVars ty
 
 tyFreeTVars :: Type -> Set TVar
 tyFreeTVars TUnit = S.empty
+tyFreeTVars TBool = S.empty
 tyFreeTVars (TVar a) = S.singleton a
 tyFreeTVars (TEVar _) = S.empty
 tyFreeTVars (TArr a b) = tyFreeTVars a <> tyFreeTVars b

--- a/src/Syntax/Type.hs
+++ b/src/Syntax/Type.hs
@@ -29,6 +29,7 @@ newtype TEVar = MkTEVar String deriving (Eq, Show, Ord, IsString)
 data Type
   = TUnit
   | TBool
+  | TNat
   | TVar TVar
   | TEVar TEVar
   | TArr Type Type
@@ -44,6 +45,7 @@ infixr 2 -->
 isMono :: Type -> Bool
 isMono TUnit = True
 isMono TBool = True
+isMono TNat = True
 isMono (TVar _) = True
 isMono (TEVar _) = True
 isMono (TArr a b) = isMono a && isMono b
@@ -52,6 +54,7 @@ isMono _ = False
 tyFreeTEVars :: Type -> Set TEVar
 tyFreeTEVars TUnit = S.empty
 tyFreeTEVars TBool = S.empty
+tyFreeTEVars TNat = S.empty
 tyFreeTEVars (TVar _) = S.empty
 tyFreeTEVars (TEVar evar) = S.singleton evar
 tyFreeTEVars (TArr a b) = tyFreeTEVars a <> tyFreeTEVars b
@@ -60,6 +63,7 @@ tyFreeTEVars (TAll _ ty) = tyFreeTEVars ty
 tyFreeTVars :: Type -> Set TVar
 tyFreeTVars TUnit = S.empty
 tyFreeTVars TBool = S.empty
+tyFreeTVars TNat = S.empty
 tyFreeTVars (TVar a) = S.singleton a
 tyFreeTVars (TEVar _) = S.empty
 tyFreeTVars (TArr a b) = tyFreeTVars a <> tyFreeTVars b

--- a/src/SystemF/Program.hs
+++ b/src/SystemF/Program.hs
@@ -27,6 +27,7 @@ module SystemF.Program
     cont,
     runCont,
     polyLet,
+    polyLetNat,
   )
 where
 
@@ -126,5 +127,10 @@ polyLet =
   ELet "id" id'
     $ ELet "myId" (EVar "id" $$ id')
     $ ELet "myUnit" (EVar "id" $$ EUnit)
-    $ EVar "myId"
-      $$ EVar "myUnit"
+    $ EVar "myId" $$ EVar "myUnit"
+
+polyLetNat =
+  ELet "id" id'
+    $ ELet "myId" (EVar "id" $$ id'')
+    $ ELet "my0" (EVar "id" $$ EZero)
+    $ ESucc (EVar "myId" $$ EVar "my0")

--- a/test/EvalSpec.hs
+++ b/test/EvalSpec.hs
@@ -35,4 +35,5 @@ evalSpec = describe "eval" $ do
   it "evals letIdUnit" $ eval letIdUnit `shouldBe` EUnit
   it "evals letNestedIdUnit" $ eval letNestedIdUnit `shouldBe` EUnit
   it "evals letNestIdUnitId" $ eval letNestIdUnitId `shouldBe` EUnit
-  it "checks applyToUnitId" $ eval applyToUnitId `shouldBe` EUnit
+  it "evals applyToUnitId" $ eval applyToUnitId `shouldBe` EUnit
+  it "evals polyLetNat" $ eval polyLetNat `shouldBe` ESucc EZero

--- a/test/TypeCheckSpec.hs
+++ b/test/TypeCheckSpec.hs
@@ -74,3 +74,6 @@ typecheckSpec = describe "typeckeck" $ do
   it "infers polyLet" $ do
     let Right (ty, _) = typecheck polyLet
     ty `shouldBe` TUnit
+  it "infers polyLetNat" $ do
+    let Right (ty, _) = typecheck polyLetNat
+    ty `shouldBe` TNat


### PR DESCRIPTION
Implemented basic types of Bool and Nat.

Functions such as `eq` and `+` for these two types are not included.